### PR TITLE
Fix default YAML path

### DIFF
--- a/bedwars-api/src/main/java/me/zypj/bedwars/api/file/YAML.java
+++ b/bedwars-api/src/main/java/me/zypj/bedwars/api/file/YAML.java
@@ -168,7 +168,7 @@ public class YAML extends YamlConfiguration {
     private void loadConfig() throws IOException, InvalidConfigurationException {
         if (!configFile.exists()) {
             String folderName = configFile.getParentFile().getName();
-            String resourcePath = folderName = "/" + configFile.getName();
+            String resourcePath = folderName + "/" + configFile.getName();
             InputStream resource = plugin.getResource(resourcePath);
 
             if (resource == null) resource = plugin.getResource(configFile.getName());


### PR DESCRIPTION
## Summary
- fix resource path construction in `YAML.loadConfig()` so default configs load correctly